### PR TITLE
Fix TDSyncBannerView delegate method being inadvertently called on a background queue

### DIFF
--- a/TritonPlayerSDK/Classes/Ads/TDSyncBannerView.m
+++ b/TritonPlayerSDK/Classes/Ads/TDSyncBannerView.m
@@ -50,7 +50,7 @@
         [self.adLoader loadAdWithStringRequest:adRequestUrl completionHandler:^(TDAd *loadedAd, NSError *error) {
             
             if (error) {
-                dispatch_async(dispatch_get_global_queue(0, 0), ^{
+                dispatch_async(dispatch_get_main_queue(), ^{
                     if ([self.delegate respondsToSelector:@selector(bannerView:didFailToPresentAdWithError:)]) {
                         [self.delegate bannerView:self didFailToPresentAdWithError:error];
                     }


### PR DESCRIPTION
Pretty sure this is a bug given the thread safety problems currently present, plus the current implementation looks non-deliberate given that all other delegate methods (e.g. `bannerViewDidPresentAd:`) are called on the main queue.