### PR TITLE
AirplaySupport Bugfix

### DIFF
--- a/TritonPlayerSDK/Classes/Player/TDStreamPlayer.m
+++ b/TritonPlayerSDK/Classes/Player/TDStreamPlayer.m
@@ -255,7 +255,7 @@ NSString *const SettingsStreamPlayerSBMURLKey = @"StreamPlayerSBMURL";
     }
 }
 
-- (void)allowsExternalPlayback:(BOOL)allow {
+- (void)setAllowsExternalPlayback:(BOOL)allow {
     
     if ([self.player respondsToSelector:@selector(setAllowsExternalPlayback:)]) {
         [self.player setAllowsExternalPlayback:allow];

--- a/TritonPlayerSDK/Classes/Player/TritonPlayer.m
+++ b/TritonPlayerSDK/Classes/Player/TritonPlayer.m
@@ -124,6 +124,9 @@ NSString *const InfoAlternateMountNameKey               = @"alternateMount";
 @property (nonatomic, strong) NSTimer *playDebouncingTimer;
 @property (nonatomic, strong) NSOperationQueue *playerOperationQueue;
 
+//Using a property to store the external playback setting because the mediaPlayer instance will be nil when play method is called.
+@property (nonatomic, assign) BOOL shouldAllowExternalPlayback;
+
 @end
 
 @implementation TritonPlayer
@@ -333,6 +336,8 @@ NSString *const InfoAlternateMountNameKey               = @"alternateMount";
         }
 
         [self.mediaPlayer play];
+        //Set the allowsExternalPlayback flag for the current media player if it's supported.
+        [self.mediaPlayer setAllowsExternalPlayback: self.shouldAllowExternalPlayback];
         
         [[NSRunLoop currentRunLoop] addPort:[NSMachPort port] forMode:NSDefaultRunLoopMode];
         while (_active) {


### PR DESCRIPTION
- Modified TritonPlayer class to set allowExternalPlayback property in startInThread method after mediaPlayer is initialised

- Fixed method name typo in TDStreamPlayer class