### PR TITLE
Add support for Audio Buffer callbacks for Triton Player

### DIFF
--- a/TritonPlayerSDK/Classes/Models/Components/AudioPlayer/AudioPlayer.h
+++ b/TritonPlayerSDK/Classes/Models/Components/AudioPlayer/AudioPlayer.h
@@ -93,8 +93,12 @@
 	AudioPlayerController			*isExecutingDelegate;
     
     NSString    *lastMessage;
-  
-	
+
+    // AUDIO QUEUE TAP
+    UInt32 outMaxFrames;
+    AudioStreamBasicDescription outProcessingFormat;
+    AudioQueueProcessingTapRef outAQTap;
+
 @public
 	
 	pthread_mutex_t mutex;			// a mutex to protect the inuse flags

--- a/TritonPlayerSDK/Classes/Player/TDFLVPlayer.m
+++ b/TritonPlayerSDK/Classes/Player/TDFLVPlayer.m
@@ -73,7 +73,7 @@ static UInt32 bufferTime = kLowDelaySecondsStart+1;
         self.flvStream = [[FLVStream alloc] initWithDelegate:self andAudioPlayerController:self.audioPlayerController secID:self.secId secReferrerURL:self.secReferrerURL lowDelay:self.lowDelay];
     
         self.flvDispather = [[FLVDispatcher alloc] initWithCuePointEventController:self.cuePointEventController andAudioPlayerController:self.audioPlayerController];
-				[self.flvDispather setTDFLVMetaDataDelegate:self];
+        [self.flvDispather setTDFLVMetaDataDelegate:self];
 				
         self.flvDecoder = [[FLVDecoder alloc] initWithStreamController:self];
         self.flvStream.flvDecoder = self.flvDecoder;
@@ -246,6 +246,12 @@ static UInt32 bufferTime = kLowDelaySecondsStart+1;
     NSError *error = [NSError errorWithDomain:TritonPlayerDomain code:TDPlayerHostNotFoundError userInfo:nil];
     self.error = error;
     [self updateStateMachineForAction:kTDPlayerActionError];
+}
+
+-(void)audioPlayerDidPlayBuffer:(AudioBufferList *)buffer {
+    if ([self.delegate respondsToSelector:@selector(mediaPlayer:didPlayBuffer:)]) {
+        [self.delegate mediaPlayer:self didPlayBuffer:buffer];
+    }
 }
 
 #pragma mark - CuePointEventController delegate

--- a/TritonPlayerSDK/Classes/Player/TDMediaPlaybackDelegate.h
+++ b/TritonPlayerSDK/Classes/Player/TDMediaPlaybackDelegate.h
@@ -23,4 +23,5 @@
 
 -(void)mediaPlayer:(id<TDMediaPlayback>)player didReceiveInfo:(TDPlayerInfo)info andExtra:(NSDictionary *)extra;
 -(void)mediaPlayer:(id<TDMediaPlayback>)player didReceiveMetaData:(NSDictionary *)metaData;
+-(void)mediaPlayer:(id<TDMediaPlayback>)player didPlayBuffer:(AudioBufferList *)buffer;
 @end

--- a/TritonPlayerSDK/Classes/Player/TDStationPlayer.m
+++ b/TritonPlayerSDK/Classes/Player/TDStationPlayer.m
@@ -595,6 +595,12 @@ NSString *const SettingsStationPlayerForceDisableHLSkey = @"StationPlayerForceDi
     }
 }
 
+- (void)mediaPlayer:(id<TDMediaPlayback>)player didPlayBuffer:(AudioBufferList *)buffer {
+    if ([self.delegate respondsToSelector:@selector(mediaPlayer:didPlayBuffer:)]) {
+        [self.delegate mediaPlayer:self didPlayBuffer:buffer];
+    }
+}
+
 #pragma mark - State machine
 
 -(BOOL)canChangeStateWithAction:(TDPlayerAction) action {

--- a/TritonPlayerSDK/Classes/Player/TDStreamPlayer.m
+++ b/TritonPlayerSDK/Classes/Player/TDStreamPlayer.m
@@ -420,6 +420,12 @@ NSString *const SettingsStreamPlayerSBMURLKey = @"StreamPlayerSBMURL";
     }
 }
 
+- (void)mediaPlayer:(id<TDMediaPlayback>)player didPlayBuffer:(AudioBufferList *)buffer {
+    if ([self.delegate respondsToSelector:@selector(mediaPlayer:didPlayBuffer:)]) {
+        [self.delegate mediaPlayer:self didPlayBuffer:buffer];
+    }
+}
+
 #pragma mark - State machine
 
 -(BOOL)canChangeStateWithAction:(TDPlayerAction) action {

--- a/TritonPlayerSDK/Classes/Player/TritonPlayer.h
+++ b/TritonPlayerSDK/Classes/Player/TritonPlayer.h
@@ -10,6 +10,7 @@
 #import <AudioToolbox/AudioQueue.h>
 #import <CoreMedia/CMTime.h>
 #import <AVFoundation/AVFoundation.h>
+#import <AudioToolbox/AudioToolbox.h>
 
 // SDK Version
 extern NSString *const TritonSDKVersion;
@@ -189,6 +190,7 @@ extern NSString *const InfoAlternateMountNameKey;
 - (void)player:(TritonPlayer *) player didReceiveCuePointEvent:(CuePointEvent *)cuePointEvent;
 - (void)player:(TritonPlayer *) player didReceiveAnalyticsEvent:(AVPlayerItemAccessLogEvent *)analyticsEvent;
 - (void)player:(TritonPlayer *) player didReceiveCloudStreamInfoEvent:(NSDictionary *)cloudStreamInfoEvent;
+- (void)player:(TritonPlayer *) player didPlayAudioBuffer:(AudioBufferList *)buffer;
 
 
 /// @name Handling interruptions

--- a/TritonPlayerSDK/Classes/Player/TritonPlayer.m
+++ b/TritonPlayerSDK/Classes/Player/TritonPlayer.m
@@ -762,6 +762,12 @@ NSString *const SettingsStreamCloudStreaming            = @"SettingsStreamCloudS
     }
 }
 
+- (void)mediaPlayer:(id<TDMediaPlayback>)player didPlayBuffer:(AudioBufferList *)buffer {
+    if ([self.delegate respondsToSelector:@selector(player:didPlayAudioBuffer:)]) {
+        [self.delegate player:self didPlayAudioBuffer: buffer];
+    }
+}
+
 #pragma mark - User Agent
 
 - (NSString*)createUserAgentString


### PR DESCRIPTION
This is needed to enable functionality of showing a music visualiser.

The audio buffer that is returned by the delegate is analysed by clients and rendered in a sound visualiser