### PR TITLE
Avoid calling didStateChange on delegate if current player state is same as next state

### DIFF
--- a/TritonPlayerSDK/Classes/Player/TritonPlayer.m
+++ b/TritonPlayerSDK/Classes/Player/TritonPlayer.m
@@ -650,9 +650,10 @@ NSString *const SettingsStreamCloudStreaming            = @"SettingsStreamCloudS
     TDPlayerState nextState = [self nextStateForAction:action];
     
     // If state changed, send the delegate a callback message
+    if (self.state != nextState) {
         self.state = nextState;
         
-    PLAYER_LOG(@"Changed state to: %@", [TritonPlayer toStringState:self.state]);
+        PLAYER_LOG(@"Changed state to: %@", [TritonPlayer toStringState:self.state]);
         
         // Clear error
         if (self.state != kTDPlayerStateError) {
@@ -664,6 +665,7 @@ NSString *const SettingsStreamCloudStreaming            = @"SettingsStreamCloudS
                 [self.delegate player:self didChangeState:self.state];
             });
         }
+    }
 }
 
 +(NSString*) toStringState:(TDPlayerState)state


### PR DESCRIPTION
Every time we start playing the radio station, the SDK calls `player:didChangeState:` method multiple times with state `connecting`.

The delegate method should be called only if the new state is different from the current state, otherwise it should be ignored.